### PR TITLE
Avoid creation of false links

### DIFF
--- a/lib/will_paginate_semantic_ui/generic_renderer.rb
+++ b/lib/will_paginate_semantic_ui/generic_renderer.rb
@@ -20,8 +20,11 @@ module WillPaginateSemanticUi
 
     def previous_or_next_page(page, classname)
       classLink = "icon item"
-      classLink += " disabled" if !page
-      link(tag("i", "", class: "#{classname} chevron icon"), page, {class: classLink})
+      unless page
+        tag(:a, tag("i", "", class: "#{classname} chevron icon"), class: classLink + " disabled")
+      else
+        link(tag("i", "", class: "#{classname} chevron icon"), page, {class: classLink})
+      end
     end
 
     def gap


### PR DESCRIPTION
Current link generation for disabled button:
```
"<a class=\"icon item\" href=\"false\"><i class=\"left chevron icon\"></i></a>"
```
Which will result in a link that not exists (/false) even if button is disabled by css. That is bad for SEO, too.

Suggested link generation for disabled button:
```
"<a class=\"icon item\"><i class=\"left chevron icon\"></i></a>"
```