### PR TITLE
Switch from deprecated class Fixnum to Integer

### DIFF
--- a/lib/will_paginate_semantic_ui/generic_renderer.rb
+++ b/lib/will_paginate_semantic_ui/generic_renderer.rb
@@ -4,7 +4,7 @@ module WillPaginateSemanticUi
 
     def to_html
       list_items = pagination.map do |item|
-        item.class == Fixnum ? page_number(item) : send(item)
+        item.class == Integer ? page_number(item) : send(item)
       end.join(@options[:link_separator])
 
       tag("div", list_items, class: ul_class)


### PR DESCRIPTION
This one fixes the deprecated Fixnum class that is still referenced and uses the Integer class instead.

I was constantly seeing the warning while running my specs so maybe we could get rid of it :)